### PR TITLE
upload-artifact@v3 오류 해결을 위한 GitHub Actions v4 업데이트

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
 
@@ -32,7 +32,7 @@ jobs:
 
       # 캐시 초기화를 위한 더미 주석
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build/


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #16 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용
- CI 실행 중 발생한 `Missing download info for actions/upload-artifact@v3` 오류를 해결하기 위해 해당 액션을 `v4`로 업그레이드

<br>

## 💬 메모
