### PR TITLE
dist 경로로 수정하고 테스트 커버리지 수집 활성화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,17 +27,16 @@ jobs:
         run: npm run lint
 
       - name: Run Tests
-        run: npm test -- --coverage
+        run: npx vitest run --coverage
 
       - name: Build Project
         run: npm run build
 
-      # 캐시 초기화를 위한 더미 주석
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build
-          path: build/
+          name: dist
+          path: dist/
 
   deploy:
     needs: build-test
@@ -48,8 +47,8 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build
-          path: build/
+          name: dist
+          path: dist/
 
       - name: Deploy to AWS S3
         uses: aws-actions/configure-aws-credentials@v2
@@ -59,7 +58,7 @@ jobs:
           aws-region: ap-northeast-2
 
       - name: Sync S3 Bucket
-        run: aws s3 sync build/ s3://huiseon-portfolio --delete
+        run: aws s3 sync dist/ s3://huiseon-portfolio --delete
 
       - name: Invalidate CloudFront Cache
         run: aws cloudfront create-invalidation --distribution-id E35IU047VVLE85 --paths "/*"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #16 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용
- GitHub Actions 내 빌드 결과물 경로를 `build/`에서 실제 사용 중인 `dist/`로 변경
- 테스트 실행 시 `vitest run --coverage`를 사용해 커버리지 수집 활성화

<br>

## 💬 메모
- 실제 빌드 디렉토리에 맞춰 CI/CD 파이프라인이 정상 작동하도록 경로 정정
- CI에서 테스트 커버리지를 수집함으로써 코드 품질을 시각화하고 유지보수에 참고할 수 있도록 구성


