### PR TITLE
vitest 설정에 alias 추가하여 CI 테스트 실패 원인을 해결한다.

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #29 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용
- `vitest.config.ts`에 `resolve.alias` 설정 추가
- 로컬 테스트 실행 시 정상 통과가 확인되어 CI 환경에서도 동일 문제 해결 예상

<br>

## 💬 메모
